### PR TITLE
Supply explicit useNativeDriver value

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-simple-gauge",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "React Native component for gauge",
   "main": "src/index.js",
   "repository": {

--- a/src/AnimatedGaugeProgress.js
+++ b/src/AnimatedGaugeProgress.js
@@ -41,6 +41,7 @@ export default class AnimatedGaugeProgress extends React.Component {
       {
         toValue: this.props.fill,
         tension,
+        useNativeDriver: false,
         friction
       }
     ).start(onAnimationComplete);


### PR DESCRIPTION
Fixes warning about useNativeDriver now being a mandatory option.